### PR TITLE
Remove Eq derive from generated request/response structs

### DIFF
--- a/messaging-thread-pool-macros/CHANGELOG.md
+++ b/messaging-thread-pool-macros/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2]
+
+### Changed
+
+* Generated request, response, API enum, and Init structs now derive `PartialEq` instead of `PartialEq, Eq`. This allows using types like `f64` and `Vec<f64>` in method signatures, which implement `PartialEq` but not `Eq`.
+
 ## [0.1.1]
 
 * Added comprehensive documentation for the `#[pool_item]` attribute macro

--- a/messaging-thread-pool-macros/Cargo.toml
+++ b/messaging-thread-pool-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "messaging-thread-pool-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["cainem"]
 description = "Macros for the messaging-thread-pool library"

--- a/messaging-thread-pool-macros/src/generation.rs
+++ b/messaging-thread-pool-macros/src/generation.rs
@@ -182,7 +182,7 @@ fn generate_request_struct(
     };
 
     quote! {
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct #request_name #impl_generics ( #(pub #request_fields),*, #phantom_data ) #where_clause;
 
         impl #impl_generics messaging_thread_pool::IdTargeted for #request_name #ty_generics #where_clause {
@@ -223,7 +223,7 @@ fn generate_response_struct(
     };
 
     quote! {
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct #response_name #impl_generics #where_clause {
             pub id: u64,
             pub result: #result_type,
@@ -314,7 +314,7 @@ fn generate_api_enum(
     quote! {
         #(#type_aliases)*
 
-        #[derive(Debug, PartialEq, Eq, Clone)]
+        #[derive(Debug, PartialEq, Clone)]
         pub enum #api_name #impl_generics #where_clause {
             #(#api_variants),*
         }
@@ -344,7 +344,7 @@ fn generate_init_struct(
     };
 
     quote! {
-        #[derive(Debug, PartialEq, Eq, Clone)]
+        #[derive(Debug, PartialEq, Clone)]
         pub struct #init_name #impl_generics (pub u64, #phantom_data) #where_clause;
 
         impl #impl_generics messaging_thread_pool::IdTargeted for #init_name #ty_generics #where_clause {

--- a/messaging-thread-pool/Cargo.toml
+++ b/messaging-thread-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "messaging_thread_pool"
-version = "5.0.1"
+version = "5.0.2"
 authors = ["cainem"]
 edition = '2024'
 description = "A library for aiding the creation of typed thread pool of objects that is communicated with via channels"
@@ -24,7 +24,7 @@ tracing-appender = "0.2.3"
 crossbeam-channel = "0.5.15"
 rand = "0.9.0"
 rand_xoshiro = "0.7.0"
-messaging-thread-pool-macros = { path = "../messaging-thread-pool-macros", version = "0.1.1" }
+messaging-thread-pool-macros = { path = "../messaging-thread-pool-macros", version = "0.1.2" }
 
 [dev-dependencies]
 criterion = "0.7.0"


### PR DESCRIPTION
Generated types now derive PartialEq instead of PartialEq + Eq.
This allows using f64 and Vec<f64> in method signatures.

- messaging-thread-pool-macros: 0.1.1 -> 0.1.2
- messaging_thread_pool: 5.0.1 -> 5.0.2
- Reorganized CHANGELOG.md to newest-first order